### PR TITLE
feat: Add support for AIProxy in Swift

### DIFF
--- a/swift/Sources/OpenMeteoSdk/OpenMeteoSdk.swift
+++ b/swift/Sources/OpenMeteoSdk/OpenMeteoSdk.swift
@@ -14,7 +14,15 @@ extension WeatherApiResponse {
     @available(iOS 13.0.0, *)
     @available(macOS 12.0, *)
     public static func fetch(url: URL, session: URLSession = URLSession.shared) async throws -> [WeatherApiResponse] {
-        let (data, response) = try await session.data(from: url)
+        var request = URLRequest(url: url)
+        return try await fetch(request: request, session: session)
+    }
+
+    @available(iOS 13.0.0, *)
+    @available(macOS 12.0, *)
+    /// Fetch data using a given URLRequest and decode the Open-Meteo Weather API Flatbuffers structure
+    public static func fetch(request: URLRequest, session: URLSession = URLSession.shared) async throws -> [WeatherApiResponse] {
+        let (data, response) = try await session.data(for: request)
         guard let res = (response as? HTTPURLResponse) else {
             throw OpenMeteoSdkError.error(message: "response is not type HTTPURLResponse")
         }


### PR DESCRIPTION
WeatherApiResponse has a public static method `fetch(url:session:)` that customers use to interact with the Open-Meteo API. This patch opens a second public static method, `fetch(request:session:)` that takes a URLRequest as the first argument.

Why?
By passing in a URLRequest, the developer is able to customize headers, which is useful if the request is first routing through a proxy. There is an AIProxy customer that would like to use your commercial API. In order for your service to be compatible with AIProxy, the end developer needs to be able to specify request headers (e.g. a DeviceCheck header, and a header that contains part of a split-key encryption scheme). These headers allow AIProxy to defend against actors that would try to steal a secret API key, or abuse a service endpoint.

I have found that the least invasive way to modify your SDK is to open this new public method. I'll open this PR as a draft to address any concerns that you may have, and I'm happy to answer questions!



